### PR TITLE
Export RowVector and ColumnVector type synonyms

### DIFF
--- a/src/Data/Matrix/Static.hs
+++ b/src/Data/Matrix/Static.hs
@@ -37,7 +37,9 @@ module Data.Matrix.Static (
   , forceMatrix
     -- * Builders
   , matrix
+  , RowVector
   , rowVector
+  , ColumnVector
   , colVector
     -- ** Special matrices
   , zero
@@ -928,6 +930,8 @@ Matrix x <-> Matrix y = Matrix $ x M.<-> y
 
 -- | A row vector (a matrix with one row).
 type RowVector = Matrix 1
+
+-- | A column vector (a matrix with one column).
 type ColumnVector m = Matrix m 1
 
 


### PR DESCRIPTION
These are convenient to have and leak through in the haddocks anyway (see, e.g., `rowVector`).